### PR TITLE
Add stub for pgp key, .well-known/security.txt, and draft vulnerability disclosure.

### DIFF
--- a/www.humanprotocol.org/.well-known/security.txt
+++ b/www.humanprotocol.org/.well-known/security.txt
@@ -1,0 +1,7 @@
+Contact: mailto:security@humanprotocol.org
+Expires: 2022-08-01T04:00:00.000Z
+Encryption: https://www.humanprotocol.org/pgp.txt
+Preferred-Languages: en
+Canonical: https://www.humanprotocol.org/.well-known/security.txt
+Policy: https://www.humanprotocol.org/vulnerability-disclosure-policy
+Hiring: https://www.humanprotocol.org/careers

--- a/www.humanprotocol.org/vulnerability-disclosure-policy.md
+++ b/www.humanprotocol.org/vulnerability-disclosure-policy.md
@@ -1,0 +1,86 @@
+**Vulnerability Disclosure Policy**
+
+_Human Protocol_
+
+_August 01, 2021_
+
+# Introduction
+
+
+The human protocol is committed to ensuring the security of their users by protecting their information. This policy is intended to give security researchers clear guidelines for conducting vulnerability discovery activities and to convey our preferences in how to submit discovered vulnerabilities to us.
+
+This policy describes  **what systems and types of research**  are covered under this policy,  **how to send us**  vulnerability reports, and  **how long**  we ask security researchers to wait before publicly disclosing vulnerabilities.
+
+We encourage you to contact us to report potential vulnerabilities in our systems.
+
+# Authorization
+
+If you make a good faith effort to comply with this policy during your security research, we will consider your research to be authorized we will work with you to understand and resolve the issue quickly, and The Human Protocol will not recommend or pursue legal action related to your research. Should legal action be initiated by a third party against you for activities that were conducted in accordance with this policy, we will make this authorization known.
+
+# Guidelines
+
+Under this policy, "research" means activities in which you:
+
+- Notify us as soon as possible after you discover a real or potential security issue.
+- Make every effort to avoid privacy violations, degradation of user experience, disruption to production systems, and destruction or manipulation of data.
+- Only use exploits to the extent necessary to confirm a vulnerability's presence. Do not use an exploit to compromise or exfiltrate data, establish persistent command line access, or use the exploit to pivot to other systems.
+- Provide us a reasonable amount of time to resolve the issue before you disclose it publicly.
+- Do not submit a high volume of low-quality reports.
+
+Once you've established that a vulnerability exists or encounter any sensitive data (including personally identifiable information, financial information, or proprietary information or trade secrets of any party), **you must stop your test, notify us immediately, and not disclose this data to anyone else**.
+
+# Test methods
+
+The following test methods are not authorized:
+
+- Network denial of service (DoS or DDoS) tests or other tests that impair access to or damage a system or data
+- Physical testing (e.g. office access, open doors, tailgating), social engineering (e.g. phishing, vishing), or any other non-technical vulnerability testing
+
+# Scope
+
+This policy applies to the following systems and services:
+
+- https://www.humanprotocol.org/\*
+- \*.humanprotocol.org
+- Source code at https://github.com/humanprotocol/
+
+**Any service not expressly listed above, such as any connected services, are excluded from scope**  and are not authorized for testing. Additionally, vulnerabilities found in systems from our vendors fall outside of this policy's scope and should be reported directly to the vendor according to their disclosure policy (if any). If you aren't sure whether a system is in scope or not, contact us at security@humanprotocol.org before starting your research.
+
+Though we develop and maintain other internet-accessible systems or services, we ask that _active research and testing_ only be conducted on the systems and services covered by the scope of this document. If there is a particular system not in scope that you think merits testing, please contact us to discuss it first. We will increase the scope of this policy over time.
+
+
+# Reporting a vulnerability
+
+- Information submitted under this policy will be used for defensive purposes only – to mitigate or remediate vulnerabilities. If your findings include newly discovered vulnerabilities that affect all users of a product or service and not solely The Human Protocol, we may share your report with the Cybersecurity and Infrastructure Security teams at partner organizations. We will not share your name or contact information without express permission.
+
+- We accept vulnerability reports via [**security@humanprotocol.org**](mailto:security@humanprotocol.org). Reports may be submitted anonymously. If you share contact information, we will acknowledge receipt of your report within 3 business days.
+
+If the reported vulnerability can be reproduced and materially impacts system operation or custom confidentiality, you may be eligible for a financial reward between $50 and $5000.
+
+## What we would like to see from you
+
+In order to help us triage and prioritize submissions, we recommend that your reports:
+
+- Describe the location the vulnerability was discovered and the potential impact of exploitation.
+- Offer a detailed description of the steps needed to reproduce the vulnerability (proof of concept scripts or screenshots are helpful).
+- Be in English, if possible.
+
+## What you can expect from us
+
+## When you choose to share your contact information with us, we commit to coordinating with you as openly and as quickly as possible.
+
+- Within 3 business days, we will acknowledge that your report has been received.
+- To the best of our ability, we will confirm the existence of the vulnerability to you and be as transparent as possible about what steps we are taking during the remediation process, including on issues or challenges that may delay resolution.
+- If the vulnerability can be reproduced and is in accordance with this vulnerability disclosure protocol, we will provide an estimate of the financial
+  compensation, a payment timeline, a request for payment information, and a disclosure timeline.`
+- We will maintain an open dialogue to discuss issues.
+
+# Questions
+
+Questions regarding this policy may be sent to [**security@humanprotocol.org**](mailto:security@humanprotocol.org). We also invite you to contact us with suggestions for improving this policy.
+
+# Document change history
+
+| **Version** | **Date** | **Description** |
+| --- | --- | --- |
+| 1.0 | August 01, 2021 | First issuance. |


### PR DESCRIPTION
Adds draft vulnerability disclosure program including scope, expectations, financial compensation, and timeline.
Includes stub for PGP keys and directs all reports to security@humanprotocol.org.

Markdown content can be typeset by Human Protocol for publishing at https://www.humanprotocol.org/vulnerability-disclosure-program. 

`.well-known/security.txt` should be signed by the encryption key published at https://www.humanprotocol.org/pgp.txt .

Closes https://github.com/humanprotocol/bugbounty/issues/1

Text of vuln disclosure derived from the USG template at https://cyber.dhs.gov/assets/report/bod-20-01-vdp-template.docx.
